### PR TITLE
Update Docker container and compose file

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,10 +1,35 @@
-version: '3.6'
+version: "3.3"
+
 services:
-  server:
-    container_name: server
+  traefik:
+    image: "traefik:v2.10"
+    container_name: "traefik"
+    command:
+      #- "--log.level=DEBUG"
+      - "--api.insecure=true"
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--entrypoints.websecure.address=:443"
+      - "--certificatesresolvers.myresolver.acme.tlschallenge=true"
+      #- "--certificatesresolvers.myresolver.acme.caserver=https://acme-staging-v02.api.letsencrypt.org/directory"
+      # Change this email address to a group email address 
+      - "--certificatesresolvers.myresolver.acme.email=hammondt@umd.edu"
+      - "--certificatesresolvers.myresolver.acme.storage=/letsencrypt/acme.json"
+    ports:
+      - "443:443"
+      - "8080:8080"
+    volumes:
+      - "./letsencrypt:/letsencrypt"
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+  vision-simulator:
     restart: always
+    expose:
+      - 8888
     build:
       context: .
       dockerfile: ./server/Dockerfile
-    ports:
-      - "8888:8888"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.whoami.rule=Host(`enes100-vision-prod.engr-prod-keystone.aws.umd.edu`)"
+      - "traefik.http.routers.whoami.entrypoints=websecure"
+      - "traefik.http.routers.whoami.tls.certresolver=myresolver"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -13,7 +13,7 @@ services:
       - "--certificatesresolvers.myresolver.acme.tlschallenge=true"
       #- "--certificatesresolvers.myresolver.acme.caserver=https://acme-staging-v02.api.letsencrypt.org/directory"
       # Change this email address to a group email address 
-      - "--certificatesresolvers.myresolver.acme.email=hammondt@umd.edu"
+      - "--certificatesresolvers.myresolver.acme.email=briandk@umd.edu"
       - "--certificatesresolvers.myresolver.acme.storage=/letsencrypt/acme.json"
     ports:
       - "443:443"

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,40 +1,44 @@
-FROM ubuntu:latest
+FROM ubuntu:18.04
 
 ENV PYTHONUNBUFFERED 1
 
 RUN echo "Installing dependencies..." && \
-    apt -y --no-install-recommends update && \ 
-    # apt -y --no-install-recommends upgrade && \
-    apt remove --purge python && apt autoremove && \
-    apt install -y --no-install-recommends \
-    python3.7 \
-    python3-pip \
-    g++ \
-    gcc \
-    libc6-dev \
-    make \
-    wget \
-    cmake \
-    git \
-    nano \
-    lsof \
-    castxml \
-    sudo
+  apt -y --no-install-recommends update && \
+  # apt -y --no-install-recommends upgrade && \
+  apt remove --purge python && apt autoremove && \
+  apt install -y --no-install-recommends \
+  python3.7 \
+  python3-pip \
+  python3-setuptools \
+  python3.7-dev \
+  gcc \
+  g++ \
+  gcc \
+  libc6-dev \
+  make \
+  wget \
+  cmake \
+  git \
+  nano \
+  lsof \
+  castxml \
+  sudo
 
 RUN echo "Installing cJSON..." && \
-	git clone https://github.com/DaveGamble/cJSON.git && \
-	cd cJSON && \
-	mkdir build && \
-	cd build && \
-	cmake .. -DENABLE_CJSON_UTILS=On -DENABLE_CJSON_TEST=Off -DCMAKE_INSTALL_PREFIX=/usr && \
-	make && \
-	make install
+  git clone https://github.com/DaveGamble/cJSON.git && \
+  cd cJSON && \
+  mkdir build && \
+  cd build && \
+  cmake .. -DENABLE_CJSON_UTILS=On -DENABLE_CJSON_TEST=Off -DCMAKE_INSTALL_PREFIX=/usr && \
+  make && \
+  make install
 
-RUN python3.7 -m pip install setuptools
-RUN python3.7 -m pip install websockets aiohttp
+RUN python3.7 -m pip install setuptools multidict websockets typing-extensions attrs yarl async_timeout idna_ssl aiosignal charset_normalizer wheel
+RUN python3.7 -m pip install aiohttp
 
 COPY ./server /server
 
 WORKDIR /server
 
 ENTRYPOINT ["/server/entrypoint.sh"]
+


### PR DESCRIPTION
The current Dockerfile does not build properly because python3.7 doesn't exist in Ubuntu:latest (now 22.04). I set this back to 18.04 which works. If the app can work under a more recent version of python that would allow for further updates.

I also updated the docker-compose.prod to provide TLS support via traefik/letsencrypt. This solves the security issue that comes up in some browsers when using the simulator. 

You should update the email address on line 15 of docker-compose-prod.yml to something your team can use. 

The frontend code in the other repo will also need to be updated to use https://enes100-vision-prod.engr-prod-keystone.aws.umd.edu [here](https://github.com/umdenes100/VisionSystemRemoteClient/blob/9b62bf9ac445e91da5174e4d7cdb4ed02d03088f/js/simulator/communication.js#L11) no port is necessary this is running on tcp/443

That new name is a newly update ec2 instance for you to use. Reach out to me with any questions. 